### PR TITLE
Move entry points from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,8 @@ include_package_data = True
 packages = find:
 python_requires = >=3.8,<3.9
 install_requires =
-    ; see envs/environment-dev.yaml for conda environment dev installation
-    ; see envs/requirements.txt for versions most recently used in development
+    # see envs/environment-dev.yaml for conda environment dev installation
+    # see envs/requirements.txt for versions most recently used in development
     arrow
     attrs
     cliff
@@ -54,3 +54,15 @@ install_requires =
     pandas
     python-hglib
     pyyaml
+    # NEMO-Cmd  # use python3 -m pip install --editable NEMO-Cmd/
+    # MOHID-Cmd  # use python3 -m pip install --editable MOHID-Cmd/
+
+[options.entry_points]
+console_scripts =
+    mohid = mohid_cmd.main:main
+
+mohid.app =
+    gather = mohid_cmd.gather:Gather
+    monte-carlo = mohid_cmd.monte_carlo:MonteCarlo
+    prepare = mohid_cmd.prepare:Prepare
+    run = mohid_cmd.run:Run

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,4 @@
 import setuptools
 
 
-setuptools.setup(
-    entry_points={
-        # The mohid command:
-        "console_scripts": ["mohid = mohid_cmd.main:main"],
-        # Sub-command plug-ins:
-        "mohid.app": [
-            "gather = mohid_cmd.gather:Gather",
-            "monte-carlo = mohid_cmd.monte_carlo:MonteCarlo",
-            "prepare = mohid_cmd.prepare:Prepare",
-            "run = mohid_cmd.run:Run",
-        ],
-    }
-)
+setuptools.setup()


### PR DESCRIPTION
Supported by setuptools>=51.0.0 since 6-Dec-2020.

This is a step along the way of modernizing packaging.