### PR TITLE
Start Monte Carlo MOHID run at spill hour

### DIFF
--- a/mohid_cmd/monte_carlo.py
+++ b/mohid_cmd/monte_carlo.py
@@ -265,13 +265,13 @@ def _render_model_dats(job_dir, runs, tmpl_env):
     """
     tmpl = tmpl_env.get_template("Model.dat")
     for i, run in runs.iterrows():
-        ## TODO: Ensure that end_date - start_date are a multiple of DT value in template
-        ##       This depends on how we handle spill hour.
-        start_date = arrow.get(run.spill_date_hour.date())
+        # Run starts at spill date hour and ends run_days later to ensure that
+        # end_date - start_date are a multiple of MOHID DT value in template
+        start_date = arrow.get(run.spill_date_hour)
         end_date = start_date.shift(days=+run.run_days - 1)
         context = {
-            "start_yyyy_mm_dd": start_date.format("YYYY MM DD"),
-            "end_yyyy_mm_dd": end_date.format("YYYY MM DD"),
+            "start_yyyy_mm_dd_hh": start_date.format("YYYY MM DD HH"),
+            "end_yyyy_mm_dd_hh": end_date.format("YYYY MM DD HH"),
         }
         (job_dir / "mohid-yaml" / f"Model-{i}.dat").write_text(tmpl.render(context))
 

--- a/mohid_cmd/monte_carlo.py
+++ b/mohid_cmd/monte_carlo.py
@@ -322,7 +322,7 @@ def _render_glost_task_scripts(
             {
                 "run_number": i,
                 "start_yyyy_mm_dd": start_date.format("YYYY-MM-DD"),
-                "n_days": run.run_days,
+                "n_days": run.run_days + 1,
             }
         )
         (job_dir / "glost-tasks" / f"{job_id}-{i}.sh").write_text(tmpl.render(context))

--- a/mohid_cmd/monte_carlo.py
+++ b/mohid_cmd/monte_carlo.py
@@ -243,7 +243,7 @@ def _render_mohid_run_yamls(
     }
     for i, run in runs.iterrows():
         start_date = arrow.get(run.spill_date_hour.date())
-        end_date = start_date.shift(days=+run.run_days)
+        end_date = start_date.shift(days=+run.run_days + 1)
         context.update(
             {
                 "run_number": i,

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -654,7 +654,7 @@ class TestRenderGlostTaskScripts:
         glost_task_sh = (glost_tasks_dir / f"{job_id}-0.sh").read_text().splitlines()
         expected = textwrap.dedent(
             f"""\
-            $HOME/.local/bin/make-hdf5 $MONTE_CARLO/forcing-yaml/AKNS-spatial-make-hdf5-0.yaml 2017-06-15 7 \\
+            $HOME/.local/bin/make-hdf5 $MONTE_CARLO/forcing-yaml/AKNS-spatial-make-hdf5-0.yaml 2017-06-15 8 \\
             && $HOME/.local/bin/mohid run --no-submit --tmp-run-dir $MONTE_CARLO/AKNS-spatial-0/ \\
               $MONTE_CARLO/mohid-yaml/AKNS-spatial-0.yaml $MONTE_CARLO/results/AKNS-spatial-0/ \\
             && bash $MONTE_CARLO/AKNS-spatial-0/MOHID.sh

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -516,8 +516,8 @@ class TestRenderModelDats:
                 """\
                 ! Note: Time period must be a multiple of DT
                 !
-                START                     : {{ start_yyyy_mm_dd }} 00 30 0
-                END                       : {{ end_yyyy_mm_dd }} 23 30 0
+                START                     : {{ start_yyyy_mm_dd_hh }} 30 0
+                END                       : {{ end_yyyy_mm_dd_hh }} 30 0
                 DT                        : 3600
 
                 VARIABLEDT                : 0
@@ -549,8 +549,8 @@ class TestRenderModelDats:
             """\
             ! Note: Time period must be a multiple of DT
             !
-            START                     : 2017 06 15 00 30 0
-            END                       : 2017 06 21 23 30 0
+            START                     : 2017 06 15 02 30 0
+            END                       : 2017 06 21 02 30 0
             DT                        : 3600
 
             VARIABLEDT                : 0

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -475,14 +475,14 @@ class TestRenderMohidRunYamls:
         assert run_desc["run_id"] == f"{job_id}-0"
         assert run_desc["paths"]["runs directory"] == f"{runs_dir}"
         expected_forcing = {
-            "winds.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/winds.hdf5",
-            "currents.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/currents.hdf5",
-            "water_levels.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/t.hdf5",
-            "temperature.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/t.hdf5",
-            "salinity.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/t.hdf5",
-            "ww3.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/waves.hdf5",
-            "e3t.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/e3t.hdf5",
-            "diffusivity.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-22jun17/t.hdf5",
+            "winds.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/winds.hdf5",
+            "currents.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/currents.hdf5",
+            "water_levels.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/t.hdf5",
+            "temperature.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/t.hdf5",
+            "salinity.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/t.hdf5",
+            "ww3.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/waves.hdf5",
+            "e3t.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/e3t.hdf5",
+            "diffusivity.hdf5": f"{forcing_dir}/{job_id}-{0}/15jun17-23jun17/t.hdf5",
         }
         assert run_desc["forcing"] == expected_forcing
         expected_run_data_files = {


### PR DESCRIPTION
Addresses the issue of all spills occurring at 00:30 on spill date.

Set run end to `run_days` to ensure that run is a multiple of MOHID DT.

Extend forcing by a day to account for run start being anytime within the first day.

