### PR TITLE
Add sbatch directive to exclude graham fat-mem nodes

### DIFF
--- a/cookiecutter/{{cookiecutter.job_dir}}/glost-job.sh
+++ b/cookiecutter/{{cookiecutter.job_dir}}/glost-job.sh
@@ -7,6 +7,7 @@
 #SBATCH --nodes={{ cookiecutter.nodes }}
 #SBATCH --ntasks-per-node={{ cookiecutter.ntasks_per_node }}
 #SBATCH --mem-per-cpu={{ cookiecutter.mem_per_cpu }}
+#SBATCH --exclude=gra[801-803]
 #SBATCH --time={{ cookiecutter.walltime }}
 #SBATCH --output={{ cookiecutter.job_dir }}/glost-job.stdout
 #SBATCH --error={{ cookiecutter.job_dir }}/glost-job.stderr

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -1214,6 +1214,7 @@ class TestGlostJobDir:
             #SBATCH --nodes={glost_run_desc["nodes"]}
             #SBATCH --ntasks-per-node=2
             #SBATCH --mem-per-cpu={glost_run_desc["mem per cpu"]}
+            #SBATCH --exclude=gra[801-803]
             #SBATCH --time=3:00:00
             #SBATCH --output={job_dir}/glost-job.stdout
             #SBATCH --error={job_dir}/glost-job.stderr


### PR DESCRIPTION
This avoids having 2 Monte Carlo runs on a single 64 core node with the same
size node-local SSD temp storage as a 32 core large-mem node.
That situation results in the 2 runs competing for SSD space during the
hdf5-to-netcdf4 transformations and causing failures due to exhausting that
storage.